### PR TITLE
ci(docs): notify kaiseki-site to rebuild on push/release

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,0 +1,51 @@
+# Add this workflow to each kaiseki package repository as
+# `.github/workflows/notify-site.yml`.
+#
+# On every push to the default branch (and on published releases) it tells the
+# kaiseki-site repo to rebuild, so the documentation site always reflects the
+# latest README / docs.
+#
+# ── HOW IT AUTHENTICATES ────────────────────────────────────────────────────
+# It mints a short-lived token from the org's `kaiseki-doc-bot` GitHub App,
+# scoped to kaiseki-site, and POSTs a `package-updated` repository_dispatch to
+# kaiseki-site (whose deploy.yml listens for that event). No per-repo secret —
+# the only stored credential is the org-level App private key (APP_PRIVATE_KEY),
+# already shared with every repo for the changelog flow. App installation tokens
+# (unlike the Actions GITHUB_TOKEN) are allowed to trigger the downstream build.
+#
+# Prerequisites (one-time, org-wide — already in place):
+#   - `kaiseki-doc-bot` App installed on all repos incl. kaiseki-site (contents: write).
+#   - `APP_ID` / `APP_PRIVATE_KEY` org secrets readable by all repos.
+
+name: Notify docs site
+
+on:
+  push:
+    branches: [master, main]
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint a token scoped to kaiseki-site
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: kaisekidev
+          repositories: kaiseki-site
+
+      - name: Dispatch rebuild of kaiseki-site
+        run: |
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/kaisekidev/kaiseki-site/dispatches \
+            -d '{"event_type":"package-updated","client_payload":{"repo":"${{ github.repository }}","sha":"${{ github.sha }}"}}'


### PR DESCRIPTION
## Summary

Wires this package into the docs-site rebuild flow. On every push to the default
branch (and on published releases) it sends a `package-updated` repository_dispatch
to `kaisekidev/kaiseki-site`, so the documentation site rebuilds with the latest
README/docs. Canary for the org-wide rollout of this workflow.

## Changes

- New `notify-site.yml`: mints a `kaiseki-doc-bot` App token scoped to kaiseki-site
  (org secrets `APP_ID`/`APP_PRIVATE_KEY`) and POSTs the dispatch. No new secret.

## Validation

- Workflow-only change; no library code touched.
- After merge, the push triggers this workflow, which must dispatch successfully and
  produce a `repository_dispatch` build run on kaiseki-site.